### PR TITLE
Trivial

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,14 +19,14 @@ Depends: ${misc:Depends},
   procps,
   python3,
   sshfs,
-  systemd
+  systemd,
 Suggests: dnsmasq,
   epoptes,
   ethtool,
   net-tools,
   nfs-kernel-server,
   openssh-server,
-  squashfs-tools
+  squashfs-tools,
 Architecture: all
 Description: Linux Terminal Server Project
  Make an installation able to netboot as an LTSP client.

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Standards-Version: 4.4.0.1
 Vcs-Git: https://github.com/ltsp/ltsp.git
 Vcs-Browser: https://github.com/ltsp/ltsp/
 Homepage: https://ltsp.github.io
+Rules-Requires-Root: no
 
 Package: ltsp
 # Try to keep dependencies to what's there in plain `debootstrap`,

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Debian LTSP Maintainers <team+ltsp@tracker.debian.org>
 Uploaders: Vagrant Cascadian <vagrant@debian.org>, Alkis Georgopoulos <alkisg@gmail.com>
 Build-Depends: debhelper (>= 9),
   ronn | ruby-ronn (<< 0.7.3-5.1) | go-md2man,
-Standards-Version: 4.4.0.1
+Standards-Version: 4.4.1
 Vcs-Git: https://github.com/ltsp/ltsp.git
 Vcs-Browser: https://github.com/ltsp/ltsp/
 Homepage: https://ltsp.github.io

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Debian LTSP Maintainers <team+ltsp@tracker.debian.org>
 Uploaders: Vagrant Cascadian <vagrant@debian.org>, Alkis Georgopoulos <alkisg@gmail.com>
 Build-Depends: debhelper (>= 9),
-  ruby-ronn | go-md2man
+  ronn | ruby-ronn (<< 0.7.3-5.1) | go-md2man,
 Standards-Version: 4.4.0.1
 Vcs-Git: https://github.com/ltsp/ltsp.git
 Vcs-Browser: https://github.com/ltsp/ltsp/

--- a/docs/ltsp.conf.5.md
+++ b/docs/ltsp.conf.5.md
@@ -3,7 +3,7 @@
 
 ## SYNOPSIS
 The LTSP client configuration file is placed at `/etc/ltsp/ltsp.conf`
-and it losely follows the .ini format. It is able to control various
+and it loosely follows the .ini format. It is able to control various
 settings of the LTSP server and clients. After each ltsp.conf modification,
 the `ltsp initrd` command needs to be run so that it's included in the
 additional ltsp.img initrd that is sent when the clients boot.


### PR DESCRIPTION
* do not require root privledges to build.
* update build-dependencies so manpages get generated on buster or newer Debian systems.
* fix typo in ltsp.conf manpage.