### PR TITLE
Feature rbd merged

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+ltsp (19.10-4) experimental; urgency=medium
+
+  [ Markus Kienast ]
+  * Ceph/RBD boot feature
+
 ltsp (19.10-1) experimental; urgency=medium
 
   [ Alkis Georgopoulos ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,44 @@
+ltsp (19.10-1) experimental; urgency=medium
+
+  [ Alkis Georgopoulos ]
+  * Correct typo, x64_32 => x86_32
+  * Enhance install/base64 commands in ltsp.conf
+  * Use x86_32 in iPXE for all x86 32bit variants
+  * Avoid dd/swap boot block on small extended partitions
+  * Use no_root_squash for NFS3 (#25)
+  * Use timeo=600 to avoid nfsmount lags (#27)
+  * Use rsize=32768,wsize=32768 instead of timeo=600 (#27)
+  * Use commas in ltsp-dnsmasq.conf dns-server option (#28)
+  * Avoid `ltsp dnsmasq` failing on multiple proxy subnets (#30)
+  * Set read_ahead_kb=4 for network mounts (#27)
+  * Blacklist floppy module (#32)
+  * Make user accounts available before 55-
+  * Customize the greeter user list (#33)
+  * Avoid section_list: not found warning (#36)
+  * Correctly set _NL
+  * Add dhcpcd to MASK_SYSTEM_SERVICES
+
+  [ DI FH Markus Kienast ]
+  * Fix PWMERGE_(SGR|DUR|DGR) (#42)
+
+  [ Alkis Georgopoulos ]
+  * Make snaps run (#44)
+
+  [ Vagrant Cascadian ]
+  * docs/ltsp.conf.5.md: Fix spelling of "loosely".
+  * debian/control:
+    - Build-Depends: Prefer "ronn" over "ruby-ronn".
+    - Update Standards-Version to 4.4.1.
+    - Set Rules-Requires-Root to "no".
+  * debian/rules:
+    - Override dh_installinit to not add init script snippets.
+    - Copy ltsp.service file into debian/ and to allow dh_installsystemd
+      to work correctly.
+  * Fix typo in ltsp-initrd man page.
+  * Fix debian/watch file.
+
+ -- Vagrant Cascadian <vagrant@debian.org>  Sat, 19 Oct 2019 13:23:20 -0700
+
 ltsp (19.09-1) unstable; urgency=low
 
   * Customize ltsp.ipxe from ltsp.conf parameters (#14)

--- a/debian/ltsp-rbd.initramfs-hook
+++ b/debian/ltsp-rbd.initramfs-hook
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# This file is part of LTSP, https://ltsp.github.io
+# Copyright 2019 the LTSP team, see AUTHORS
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Inject LTSP code under initramfs-tools
+
+# Hook scripts (from man initramfs-tools(8))
+# These  are  used  when an initramfs image is created and not included in the
+# image itself. They can however cause files to be included in the image.  Hook
+# scripts are executed under errexit.  Thus  a hook script can abort the
+# mkinitramfs build on possible errors (exitcode != 0).
+
+# Notes:
+# Use functions and local variables, to avoid namespace pollution
+
+# Initramfs hook for ltsp
+
+PREREQ=""
+
+prereqs()
+{
+    echo "$PREREQ"
+}
+
+case "$1" in
+    prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+modules="rbd aes cbc"
+manual_add_modules $modules

--- a/debian/ltsp-rbd.initramfs-script
+++ b/debian/ltsp-rbd.initramfs-script
@@ -1,0 +1,225 @@
+# This file is part of LTSP, https://ltsp.github.io
+# Originally written by Paul Emmerich, emmericp@net.in.tum.de
+# Extended and adapted for LTSP by Markus Kienast, mark@trickkiste.at
+# Based on the initramfs-tools nfs script.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Inject LTSP code under initramfs-tools
+
+# RBD root mounting			-*- shell-script -*-
+
+
+rbd_top()
+{
+	if [ "${rbd_top_used}" != "yes" ]; then
+		[ "$quiet" != "y" ] && log_begin_msg "Running /scripts/rbd-top"
+		run_scripts /scripts/rbd-top
+		[ "$quiet" != "y" ] && log_end_msg
+	fi
+	rbd_top_used=yes
+}
+
+rbd_premount()
+{
+	if [ "${rbd_premount_used}" != "yes" ]; then
+		[ "$quiet" != "y" ] && log_begin_msg "Running /scripts/rbd-premount"
+		run_scripts /scripts/rbd-premount
+		[ "$quiet" != "y" ] && log_end_msg
+	fi
+	rbd_premount_used=yes
+}
+
+rbd_bottom()
+{
+	if [ "${rbd_premount_used}" = "yes" ] || [ "${rbd_top_used}" = "yes" ]; then
+		[ "$quiet" != "y" ] && log_begin_msg "Running /scripts/rbd-bottom"
+		run_scripts /scripts/rbd-bottom
+		[ "$quiet" != "y" ] && log_end_msg
+	fi
+	rbd_premount_used=no
+	rbd_top_used=no
+}
+
+# parse rbd bootargs and mount rbd
+rbd_map_root_impl()
+{
+	configure_networking
+
+	# get rbd root from dhcp
+	if [ "x${RBDROOT}" = "xauto" ]; then
+		RBDROOT=${ROOTPATH}
+	fi
+
+	local mons user key pool image snap partition
+
+	# rbdroot=<mons>:<user>:<key>:<pool>:<image>[@<snapshot>]:[<partition>]:[<mountopts>]
+	if [ -n "${RBDROOT}" ]; then
+		local i=1
+		local OLD_IFS=${IFS}
+		IFS=":"
+		for arg in ${RBDROOT} ; do
+			case ${i} in
+				1)
+					mons=$(echo ${arg} | tr ";" ":")
+					;;
+				2)
+					user=${arg}
+					;;
+				3)
+					key=${arg}
+					;;
+				4)
+					pool=${arg}
+					;;
+				5)
+					# image contains an @, i.e. a snapshot
+					if [ ${arg#*@*} != ${arg} ] ; then
+						image=${arg%%@*}
+						snap=${arg##*@}
+					else
+						image=${arg}
+						snap=""
+					fi
+					;;
+				6)
+					partition=${arg}
+					;;
+				7)
+				  mountopts=${arg}
+					;;
+			esac
+			i=$((${i} + 1))
+		done
+		IFS=${OLD_IFS}
+	fi
+
+	# the kernel will reject writes to add if add_single_major exists
+	local rbd_bus
+	if [ -e /sys/bus/rbd/add_single_major ]; then
+		rbd_bus=/sys/bus/rbd/add_single_major
+	elif [ -e /sys/bus/rbd/add ]; then
+		rbd_bus=/sys/bus/rbd/add
+	else
+		echo "ERROR: /sys/bus/rbd/add does not exist"
+		return 1
+	fi
+
+  ### FIXME: this must not repeat if successful but mount fails for some reason
+
+	# tell the kernel rbd client to map the block device
+	echo "${mons} name=${user},secret=${key} ${pool} ${image} ${snap}" > ${rbd_bus}
+	# figure out where the block device appeared
+	dev=$(ls /dev/rbd* | grep '/dev/rbd[0-9]*$' | tail -n 1)
+	# add partition if set
+	if [ ${partition} ]; then
+		dev=${dev}p${partition}
+	fi
+}
+
+rbd_mount_root_impl()
+{
+	if [ ${readonly} = y ]; then
+		roflag="-r"
+	else
+		roflag="-w"
+	fi
+
+	if [[ ! -z "$mountopts" ]] ; then
+		mountopts="-o $mountopts"
+	fi
+
+	# get the root filesystem type if not set
+	if [ -z "${ROOTFSTYPE}" ]; then
+		FSTYPE=$(get_fstype "${dev}")
+	else
+		FSTYPE=${ROOTFSTYPE}
+	fi
+
+	rbd_premount
+
+	# mount the fs
+	modprobe ${FSTYPE}
+	echo "EXECUTING: \"mount -t ${FSTYPE} ${roflag},${mountopts} $dev ${rootmnt}\""
+	mount -t ${FSTYPE} ${roflag} ${mountopts} $dev ${rootmnt}
+
+}
+
+
+# RBD root mounting
+rbd_mount_root()
+{
+
+	export RBDROOT=
+
+	# Parse command line options for rbdroot option
+	for x in $(cat /proc/cmdline); do
+		case $x in
+		rbdroot=*)
+			RBDROOT="${x#rbdroot=}"
+			;;
+		esac
+	done
+
+	rbd_top
+
+	modprobe rbd
+	# For DHCP
+	modprobe af_packet
+
+	wait_for_udev 10
+
+	# Default delay is around 180s
+	delay=${ROOTDELAY:-120}
+
+	# loop until rbd mount succeeds
+	rbd_map_root_impl
+	rbd_map_retry_count=0
+	while [ ${rbd_map_retry_count} -lt ${delay} ] \
+		&& [[ -z "$dev" ]] ; do
+		[ "$quiet" != "y" ] && log_begin_msg "Retrying rbd map"
+		/bin/sleep 1
+		rbd_map_root_impl
+		rbd_map_retry_count=$(( ${rbd_map_retry_count} + 1 ))
+		[ "$quiet" != "y" ] && log_end_msg
+	done
+
+  if [ -z "$dev" ] ; then
+		echo "ERROR: RBD could not be mapped"
+		return 1
+	fi
+
+	# loop until rbd mount succeeds
+	rbd_mount_root_impl
+	rbd_mount_retry_count=0
+	while [ ${rbd_mount_retry_count} -lt ${delay} ] \
+		&& ! chroot "${rootmnt}" test -x "${init}" ; do
+		[ "$quiet" != "y" ] && log_begin_msg "Retrying rbd mount"
+		/bin/sleep 1
+		rbd_mount_root_impl
+		rbd_mount_retry_count=$(( ${rbd_mount_retry_count} + 1 ))
+		[ "$quiet" != "y" ] && log_end_msg
+	done
+}
+
+mountroot()
+{
+	rbd_mount_root
+}
+
+mount_top()
+{
+	# Note, also called directly in case it's overridden.
+	rbd_top
+}
+
+mount_premount()
+{
+	# Note, also called directly in case it's overridden.
+	rbd_premount
+}
+
+mount_bottom()
+{
+	# Note, also called directly in case it's overridden.
+	rbd_bottom
+}

--- a/debian/rules
+++ b/debian/rules
@@ -27,8 +27,13 @@ override_dh_install:
 	sed "s/^\(_VERSION=\).*/\1'$(DEB_VERSION)'/" -i "$(CURDIR)"/debian/ltsp/usr/share/ltsp/ltsp
 	cp ltsp/common/service/ltsp.service debian/
 	mkdir -p "$(CURDIR)/debian/ltsp/usr/share/initramfs-tools/hooks"
+	mkdir -p "$(CURDIR)/debian/ltsp/usr/share/initramfs-tools/scripts"
 	# hooks/ltsp conflicts with ltsp-client-core
 	cp -a "$(CURDIR)/debian/ltsp.initramfs-hook" "$(CURDIR)/debian/ltsp/usr/share/initramfs-tools/hooks/ltsp-next"
+	# initramfs-tools hook, so rbd modules will be included in initrd
+	cp -a "$(CURDIR)/debian/ltsp-rbd.initramfs-hook" "$(CURDIR)/debian/ltsp/usr/share/initramfs-tools/hooks/ltsp-rbd-next"
+	# initramfs-tools script, so we can boot from rbd
+	cp -a "$(CURDIR)/debian/ltsp-rbd.initramfs-script" "$(CURDIR)/debian/ltsp/usr/share/initramfs-tools/scripts/rbd"
 
 override_dh_clean:
 	rm -f debian/ltsp.service

--- a/ltsp/common/info/55-info.sh
+++ b/ltsp/common/info/55-info.sh
@@ -32,4 +32,6 @@ info_main() {
     list_img_names -v
     printf "\nIMAGES:\n"
     list_img_names -i
+    printf "\nCMDLINE_BOOT_METHODS:\n"
+    list_img_names -m
 }

--- a/ltsp/common/ltsp/55-images.sh
+++ b/ltsp/common/ltsp/55-images.sh
@@ -98,7 +98,7 @@ list_img_names() {
         fi
         if [ "$listm" = "1" ]; then
             for img_path in "$BASE_DIR/cmdline_boot_method/"*; do
-                test -f "$img_path" || continue
+                test -d "$img_path" || continue
                 img_path_to_name "$img_path"
             done
         fi

--- a/ltsp/common/ltsp/55-images.sh
+++ b/ltsp/common/ltsp/55-images.sh
@@ -66,12 +66,13 @@ list_img_names() {
     # chroots, VMs, exported images
     local listc listv listi img_path img_names
 
-    test "$#" -ne 0 || set -- -c -v -i
+    test "$#" -ne 0 || set -- -c -v -i -m
     while [ -n "$1" ]; do
         case "$1" in
             -c) listc=1 ;;
             -v) listv=1 ;;
             -i) listi=1 ;;
+            -m) listm=1 ;;
             *)  die "Error in list_all_images"
         esac
         shift
@@ -91,6 +92,12 @@ list_img_names() {
         fi
         if [ "$listi" = "1" ]; then
             for img_path in "$BASE_DIR/images/"*.img; do
+                test -f "$img_path" || continue
+                img_path_to_name "$img_path"
+            done
+        fi
+        if [ "$listm" = "1" ]; then
+            for img_path in "$BASE_DIR/cmdline_boot_method/"*; do
                 test -f "$img_path" || continue
                 img_path_to_name "$img_path"
             done

--- a/ltsp/common/ltsp/ltsp.conf
+++ b/ltsp/common/ltsp/ltsp.conf
@@ -14,6 +14,16 @@
 # Specify an alternative TFTP_DIR
 # TFTP_DIR=/var/lib/tftpboot
 
+# Specify a CMDLINE_BOOT_METHOD for alternative boot methodes like RBD or iSCSI.
+# Here is an example RBD boot cmdline:
+# It follows this form: rbdroot=<mons>:<user>:<key>:<pool>:<image>[@<snapshot>]:[<partition>]:[<mountopts>]
+# Be aware that user is the username part only not "client.username" as often
+# referred to in Ceph. If the MON services listen on a non-standard port, port
+# shall be specified with ";" instead of standard ":" for obvious reasons -
+# e.g. host;7000
+# If you want to use the ${img} variable, you must use single quotes.
+# CMDLINE_BOOT_METHOD='boot=rbd ro rbdroot=10.101.0.4,10.101.0.5,10.101.0.6:user:secretkey==:rbd:${img}:1:'
+
 # In the special [clients] section, parameters for all clients can be defined.
 # Most ltsp.conf parameters should be placed here.
 [clients]

--- a/ltsp/server/ipxe/55-ipxe.sh
+++ b/ltsp/server/ipxe/55-ipxe.sh
@@ -28,7 +28,7 @@ ipxe_cmdline() {
 }
 
 ipxe_main() {
-    local key items gotos r_items r_gotos img_name title client_sections binary
+    local key items gotos r_items r_gotos img_name title client_sections binary sedp
 
     # Prepare the menu text for all images and chroot
     key=0
@@ -43,6 +43,11 @@ ipxe_main() {
         items="${items:+"$items\n"}$(printf "item --key %d %-20s %s" "$((key%10))" "$img_name" "$title")"
         gotos=":$img_name\n$gotos"
     done
+    # FIXME: Alkis, it seems you are using the "r_" prefix here to prevent
+    # naming collisions. However, such collisions still would occure in
+    # /srv/tftp/ltsp, as you are not using a "roots" subdirectory to separate
+    # these namespaces. I have implemented the cmdline_boot_method items without
+    # the prefix in ipxe menu for that reason.
     r_items=""
     r_gotos=":roots"
     img_name=$(re list_img_names -c)
@@ -54,20 +59,36 @@ ipxe_main() {
         r_items="${r_items:+"$r_items\n"}$(printf "item --key %d %-20s %s" "$((key%10))" "r_$img_name" "$title")"
         r_gotos=":r_$img_name\nset img $img_name \&\& goto roots\n$r_gotos"
     done
+    m_items=""
+    m_gotos=":cmdline_boot_method"
+    img_name=$(re list_img_names -m)
+    set -- $img_name
+    for img_name in "$@"; do
+        key=$((key+1))
+        title=$(echo_values "$(ipxe_name "$img_name")")
+        title=${title:-$img_name}
+        m_items="${m_items:+"$m_items\n"}$(printf "item --key %d %-20s %s" "$((key%10))" "$img_name" "$title")"
+        m_gotos=":$img_name\nset img $img_name \&\& goto cmdline_boot_method\n$m_gotos"
+    done
     re mkdir -p "$TFTP_DIR/ltsp"
     if [ "$OVERWRITE" != "1" ] && [ -f "$TFTP_DIR/ltsp/ltsp.ipxe" ]; then
         warn "Configuration file already exists: $TFTP_DIR/ltsp/ltsp.ipxe
 To overwrite it, run: ltsp --overwrite $_APPLET ..."
     else
         client_sections=$(re client_sections)
-        re install_template "ltsp.ipxe" "$TFTP_DIR/ltsp/ltsp.ipxe" "\
+
+        sedp="\
 s|^/srv/ltsp|$BASE_DIR|g
 s/\(|| set menu-timeout \)5000/$(textif "$MENU_TIMEOUT" "\1$MENU_TIMEOUT" "&")/
 s|^:61:6c:6b:69:73:67\$|$(textif "$client_sections" "$client_sections" "&")|
-s|^#.*item.*\bimages\b.*|$(textif "$items$r_items" "$items\n$r_items" "&")|
-s|^:images\$|$(textif "$items" "$gotos" "&")|
+s|^#.*item.*\bimages\b.*|$(textif "$m_items$items$r_itmes" "$m_items\n$items\n$r_items" "&")|
 s|^:roots\$|$(textif "$r_items" "$r_gotos" "&")|
+s|^:images\$|$(textif "$items" "$gotos" "&")|
+s|^:cmdline_boot_method\$|$(textif "$m_items" "$m_gotos" "&")|
+s|\${CMDLINE_BOOT_METHOD}\$|$(textif "$CMDLINE_BOOT_METHOD" "$CMDLINE_BOOT_METHOD" "&")|
 "
+
+        re install_template "ltsp.ipxe" "$TFTP_DIR/ltsp/ltsp.ipxe" "$sedp"
     fi
     if [ "$BINARIES" != "0" ]; then
         # Prefer memtest.0 from ipxe.org over the one from distributions:
@@ -129,4 +150,3 @@ ipxe_name() {
     echo "$*" |
         awk '{ var=toupper($0); gsub("[^A-Z0-9]", "_", var); print "IPXE_" var }'
 }
-

--- a/ltsp/server/ipxe/ltsp.ipxe
+++ b/ltsp/server/ipxe/ltsp.ipxe
@@ -41,23 +41,31 @@ item --key x exit                 Exit iPXE and continue BIOS boot
 choose --timeout ${menu-timeout} --default ${img} img || goto cancel
 goto ${img}
 
+:cmdline_boot_method
+# If CMDLINE_BOOT_METHOD is set in ltsp.conf, the selection of an LTSP image in
+# the menu will execute this target. You can use ${img} in CMDLINE_BOOT_METHOD
+# to allow different images to be selected with the same CMDLINE_BOOT_METHOD.
+# See Ceph/RBD example in ltsp.conf.
+set cmdline_boot_method ${CMDLINE_BOOT_METHOD}
+goto ltsp
+
 :images
 # The "images" method can boot anything in /srv/ltsp/images
-set cmdline_method root=/dev/nfs nfsroot=${srv}:/srv/ltsp ltsp.image=images/${img}.img loop.max_part=9
+set cmdline_boot_method root=/dev/nfs nfsroot=${srv}:/srv/ltsp ltsp.image=images/${img}.img loop.max_part=9
 goto ltsp
 
 :roots
 # The "roots" method can boot all /srv/ltsp/roots
-set cmdline_method root=/dev/nfs nfsroot=${srv}:/srv/ltsp/${img}
+set cmdline_boot_method root=/dev/nfs nfsroot=${srv}:/srv/ltsp/${img}
 goto ltsp
 
 :ltsp
-# :images and :roots jump here after setting cmdline_method
-set cmdline ${cmdline_method} ${cmdline_ltsp} ${cmdline_client}
+# :images and :roots jump here after setting cmdline_boot_method
+set cmdline ${cmdline_boot_method} ${cmdline_ltsp} ${cmdline_client}
 # In EFI mode, iPXE requires initrds to be specified in the cmdline
-kernel /ltsp/${img}/vmlinuz initrd=ltsp.img initrd=initrd.img ${cmdline}
-initrd /ltsp/ltsp.img
+kernel /ltsp/${img}/vmlinuz initrd=initrd.img initrd=ltsp.img ${cmdline}
 initrd /ltsp/${img}/initrd.img
+initrd /ltsp/ltsp.img
 boot || goto failed
 
 :memtest

--- a/ltsp/server/isc-dhcp-server/maas-dhcpd-snippet.conf
+++ b/ltsp/server/isc-dhcp-server/maas-dhcpd-snippet.conf
@@ -1,0 +1,46 @@
+# This file is part of LTSP, https://ltsp.github.io
+# Copyright 2019 the LTSP team, see AUTHORS
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# MAAS isc-dhcp-server snippet for LTSP
+# in order to boot LTSP in a subnet add a global DHCP snippet and one to the
+# subnet, which you desire to enbale LTSP on.
+# Documentation=man:ltsp(8)
+
+##################
+# global snippet #
+##################
+
+option space ltspipxe;
+option ltspipxe-encap-opts code 175 = encapsulate ltspipxe;
+option ltspipxe.menu code 39 = unsigned integer 8;
+option ltspipxe.no-pxedhcp code 176 = unsigned integer 8;
+option arch code 93 = unsigned integer 16;
+
+##################
+# subnet snippet #
+##################
+
+option ltspipxe.no-pxedhcp 1;
+# On single-NIC setups, usually routers != next-server (=TFTP server)
+# option next-server 192.168.67.1
+if exists ltspipxe.menu {
+  filename "ltsp/ltsp.ipxe";
+} elsif option arch = 00:00 {
+  filename "ltsp/undionly.kpxe";
+} elsif option arch = 00:07 {
+  filename "ltsp/snponly.efi";
+} elsif option arch = 00:09 {
+  filename "ltsp/snponly.efi";
+} else {
+  filename "ltsp/unmatched-client";
+}
+
+
+# Example for a host with static IP address and default ltspipxe menu entry
+# host pc01 {
+#   hardware ethernet 1c:69:7a:02:c1:5c;
+#   fixed-address 192.168.67.7;
+#   option host-name "pc01";
+#   option root-path "ltspipxe-menu-item";
+# }


### PR DESCRIPTION
Hi @alkisg,

I have finished my Ceph/RBD boot feature and everything works well.

As you proposed, I managed to do so by only using initramfs hooks and scripts. I kept them separate from the main ltsp initramfs magic. One reason being, that it will be easier to purge these file, if eventually rbd extensions will make it to upstream initramfs-tools.

I followed your proposed CMDLINE_METHOD path, but changed the naming to CMDLINE_BOOT_METHOD because it is more literal and therefore enables people to more quickly understand what is going on.

ltsp kernel should also work, if the RBD is mounted to the respective /srv/ltsp directory. It should then be treated like a chroot.

My best regards,
Markus

PS: Next step is to enable CephFS /home, which should be fairly easy in comparison.