### PR TITLE
Feature BOOT_METHOD

### DIFF
--- a/ltsp/common/ltsp/ltsp.conf
+++ b/ltsp/common/ltsp/ltsp.conf
@@ -7,12 +7,63 @@
 # Enable NAT on dual NIC servers
 # NAT=1
 # Provide a full menu name for x86_32.img when `ltsp ipxe` runs
-# IPXE_X86_32_IMG="Debian Buster"
+# REPLACED by BOOT_METHOD_[0-9]*_BOOTNAME, see below! IPXE_X86_32_IMG="Debian Buster"
 
 # The special [common] section is evaluated by both the server and ltsp clients
 [common]
 # Specify an alternative TFTP_DIR
 # TFTP_DIR=/var/lib/tftpboot
+
+### INFO (to be removed):
+# Doing away with a predefined standard boot method in 55-ipxe.sh makes LTSP
+# more generic and adaptable to any needs.
+#
+# The 6 lines for BOOT_METHOD_1 and BOOT_METHOD_2 setup ltsp.ipxe with exactly
+# the same functionality as before, but they can also be changed or turned off
+# completely without having to modify 55-ipxe.sh.
+#
+# The scripts look for image.img files or directories with a /proc subdir and
+# set them up for booting the respective BOOT_METHOD.
+
+# BOOT_METHOD_[0-9]*
+# The respective BOOT_METHOD is applied to all *.img or chroots found in the
+# specified DIR. Each directory should exclusively contain either *.img files or
+# chroots (a dir with subdir /proc present is enough). DIR is always relative to
+# $BASE_DIR and can be left unset or empty, if the targets reside in $BASE_DIR.
+# The search for *.img and chroots is not recursive.
+# Variables like ${img} or ${srv} may be used, if the string is enclosed in
+# single quotes.
+# You can savely apply different BOOT_METHODs to the same image directory.
+
+BOOT_METHOD_1='root=/dev/nfs nfsroot=${srv}:/srv/ltsp ltsp.image=images/${img}.img loop.max_part=9'
+BOOT_METHOD_1_DIR="images"
+BOOT_METHOD_1_NAME="Boot squashfs images via NFS in LTSP mode:"
+
+# If DIR is empty or unset, $BASE_DIR is being used.
+BOOT_METHOD_2='root=/dev/nfs nfsroot=${srv}:/srv/ltsp/${img}'
+BOOT_METHOD_2_DIR=""
+BOOT_METHOD_5_NAME="Boot NFS root directories:"
+
+# A custom title may be applied to a menu item with "BOOT_METHOD_<NUMBER>_<NAME>
+# <NAME> is the *.img file or chroot dir name converted to uppercase and with
+# any characters not in [0-9A-Z] converted to underscores - e.g. tails-01 would
+# become TAILS_01.
+# BOOT_METHOD_3_TAILS_01="Tails Live CD"
+# To define a default menu entry, set BOOT_DEFAULT to "BOOT_METHOD_<NUMBER>_<NAME>
+# BOOT_DEFAULT="BOOT_METHOD_3_TAILS_01"
+
+# RBD BOOT_METHOD example:
+# It follows this form: rbdroot=<mons>:<user>:<key>:<pool>:<image>[@<snapshot>]:[<partition>]:[<mountopts>]
+# Be aware that user is the username part only not "client.username" as often
+# referred to in Ceph. If the MON services listen on a non-standard port, port
+# shall be specified with ";" instead of standard ":" for obvious reasons -
+# e.g. host;7000
+# BOOT_METHOD_3='boot=rbd ro rbdroot=10.101.0.4,10.101.0.5,10.101.0.6:user:secretkey==:rbd:${img}:1:'
+# BOOT_METHOD_3_DIR="rbd"
+# BOOT_METHOD_3_NAME="RBD ro:"
+
+# iSCSI BOOT_METHOD example:
+# To be added later.
 
 # In the special [clients] section, parameters for all clients can be defined.
 # Most ltsp.conf parameters should be placed here.

--- a/ltsp/server/ipxe/55-ipxe.sh
+++ b/ltsp/server/ipxe/55-ipxe.sh
@@ -7,6 +7,15 @@
 
 BINARIES_URL=${BINARIES_URL:-https://github.com/ltsp/binaries/releases/latest/download}
 
+ipxe_lowercase() {
+    echo "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+ipxe_prepvar() {
+    echo "$*" |
+        awk '{ var=toupper($0); gsub("[^A-Z0-9]", "_", var); print var }'
+}
+
 ipxe_cmdline() {
     local args
 
@@ -28,46 +37,66 @@ ipxe_cmdline() {
 }
 
 ipxe_main() {
-    local key items gotos r_items r_gotos img_name title client_sections binary
+    local key items gotos methods boot_name boot_names item_label title client_sections binary sedp subdir boot_method_vars boot_method_var boot_method boot_method_name boot_method_target is_default
 
-    # Prepare the menu text for all images and chroot
+    # Prepare the menu text for all images and chroots
     key=0
-    items=""
-    gotos=":images"
-    img_name=$(re list_img_names -i)
-    set -- $img_name
-    for img_name in "$@"; do
+    items=""   # The menu items to be inserted.
+    gotos=""   # Jump targets setting correct ${img} var for menu items.
+    methods="" # Jump targets with the respective boot_method.
+
+    # INFO: The images/chroots automatism has been removed. It has been replaced
+    # by the BOOT_METHOD functionality, which can achieve the same thing but
+    # without hardwiring LTSP to any specific BOOT_METHOD.
+    # As a side effect some code repititions have also been remove.
+
+    # Extracts all vars with pattern BOOT_METHOD_[0-9]* and prepares boot
+    # options for their respective dirs.
+    boot_method_vars=$(echo_vars "BOOT_METHOD_[0-9]*")
+    set -- $boot_method_vars
+
+    for boot_method_var in "$@"; do
+      eval "subdir=\$${boot_method_var}_DIR"
+      eval "boot_method=\$${boot_method_var}"
+      eval "boot_method_name=\$${boot_method_var}_NAME"
+      boot_method_target=$(ipxe_lowercase ${boot_method_var})
+      methods="${methods}${boot_method_target}:\nset cmdline_boot_method $boot_method \&\& goto ltsp\n"
+      items="${items:+"$items\n"}$(printf "item --gap %s" "$boot_method_name")"
+      boot_names=$(re list_boot_names $BASE_DIR/$subdir)
+      set -- $boot_names
+      for boot_name in "$@"; do
         key=$((key+1))
-        title=$(echo_values "$(ipxe_name "$img_name.img")")
-        title=${title:-$img_name.img}
-        items="${items:+"$items\n"}$(printf "item --key %d %-20s %s" "$((key%10))" "$img_name" "$title")"
-        gotos=":$img_name\n$gotos"
+        [ $(ipxe_prepvar "${boot_method_var}_${boot_name}") = "${BOOT_DEFAULT}" ] && is_default=" --default" || is_default=""
+        item_label=${key}_${boot_name}
+        title=$(echo_values "$(ipxe_prepvar "${boot_method_var}_${boot_name}")")
+        title="${title:-${boot_name} (./${subdir}${subdir:+/}${boot_name})}"
+        if [ $key -lt 10 ]; then
+          items="${items:+"$items\n"}$(printf "item%s --key %d %-20s %s" "$is_default" "$((key%10))" "$item_label" "$title")"
+        else
+          items="${items:+"$items\n"}$(printf "item%s %-28s %s" "$is_default" "$((key%10))" "$item_label" "$title")"
+        fi
+        gotos="$gotos:${item_label}:\nset img $boot_name \&\& goto ${boot_method_target}\n"
+
+      done
     done
-    r_items=""
-    r_gotos=":roots"
-    img_name=$(re list_img_names -c)
-    set -- $img_name
-    for img_name in "$@"; do
-        key=$((key+1))
-        title=$(echo_values "$(ipxe_name "$img_name")")
-        title=${title:-$img_name}
-        r_items="${r_items:+"$r_items\n"}$(printf "item --key %d %-20s %s" "$((key%10))" "r_$img_name" "$title")"
-        r_gotos=":r_$img_name\nset img $img_name \&\& goto roots\n$r_gotos"
-    done
+
     re mkdir -p "$TFTP_DIR/ltsp"
     if [ "$OVERWRITE" != "1" ] && [ -f "$TFTP_DIR/ltsp/ltsp.ipxe" ]; then
         warn "Configuration file already exists: $TFTP_DIR/ltsp/ltsp.ipxe
 To overwrite it, run: ltsp --overwrite $_APPLET ..."
     else
         client_sections=$(re client_sections)
-        re install_template "ltsp.ipxe" "$TFTP_DIR/ltsp/ltsp.ipxe" "\
+
+        sedp="\
 s|^/srv/ltsp|$BASE_DIR|g
 s/\(|| set menu-timeout \)5000/$(textif "$MENU_TIMEOUT" "\1$MENU_TIMEOUT" "&")/
 s|^:61:6c:6b:69:73:67\$|$(textif "$client_sections" "$client_sections" "&")|
-s|^#.*item.*\bimages\b.*|$(textif "$items$r_items" "$items\n$r_items" "&")|
-s|^:images\$|$(textif "$items" "$gotos" "&")|
-s|^:roots\$|$(textif "$r_items" "$r_gotos" "&")|
+s|^#.*item.*\bimages\b.*|$(textif "$items" "$items" "&")|
+s|^:gotos\$|$(textif "$items" "$gotos" "&")|
+s|^:boot_methods\$|$(textif "$items" "$methods" "&")|
 "
+
+        re install_template "ltsp.ipxe" "$TFTP_DIR/ltsp/ltsp.ipxe" "$sedp"
     fi
     if [ "$BINARIES" != "0" ]; then
         # Prefer memtest.0 from ipxe.org over the one from distributions:
@@ -129,4 +158,3 @@ ipxe_name() {
     echo "$*" |
         awk '{ var=toupper($0); gsub("[^A-Z0-9]", "_", var); print "IPXE_" var }'
 }
-

--- a/ltsp/server/ipxe/ltsp.ipxe
+++ b/ltsp/server/ipxe/ltsp.ipxe
@@ -28,7 +28,6 @@ goto ${mac} || goto start
 isset ${menu-timeout} || set menu-timeout 5000
 iseq "${menu-timeout}" "-1" && goto ${img} ||
 menu iPXE boot menu - ${hostname}:${srv}:${root-path} || goto ${img}
-item --gap                        Boot an image from the network in LTSP mode:
 # item --key 1 images             x86_64
 item
 item --gap                        Other options:
@@ -41,23 +40,19 @@ item --key x exit                 Exit iPXE and continue BIOS boot
 choose --timeout ${menu-timeout} --default ${img} img || goto cancel
 goto ${img}
 
-:images
-# The "images" method can boot anything in /srv/ltsp/images
-set cmdline_method root=/dev/nfs nfsroot=${srv}:/srv/ltsp ltsp.image=images/${img}.img loop.max_part=9
-goto ltsp
+# Jump targets setting correct ${img} var for menu items.
+:gotos
 
-:roots
-# The "roots" method can boot all /srv/ltsp/roots
-set cmdline_method root=/dev/nfs nfsroot=${srv}:/srv/ltsp/${img}
-goto ltsp
+# Jump targets with the respective boot_method.
+:boot_methods
 
 :ltsp
-# :images and :roots jump here after setting cmdline_method
-set cmdline ${cmdline_method} ${cmdline_ltsp} ${cmdline_client}
+# :images and :roots jump here after setting cmdline_boot_method
+set cmdline ${cmdline_boot_method} ${cmdline_ltsp} ${cmdline_client}
 # In EFI mode, iPXE requires initrds to be specified in the cmdline
-kernel /ltsp/${img}/vmlinuz initrd=ltsp.img initrd=initrd.img ${cmdline}
-initrd /ltsp/ltsp.img
+kernel /ltsp/${img}/vmlinuz initrd=initrd.img initrd=ltsp.img ${cmdline}
 initrd /ltsp/${img}/initrd.img
+initrd /ltsp/ltsp.img
 boot || goto failed
 
 :memtest


### PR DESCRIPTION
Hi @alkisg,

here is my proposal to universally manage LTSP BOOT_METHODs.

It removes any predefined way to boot from 55-ipxe.sh and instead moves this determination to ltsp.conf. 

The ltsp.conf included in the Debian package would then simply contain a default set of BOOT_METHODs, which sets up LTSP to provide exactly the same boot methods, which are in place now (images and roots).

But of course, this way you can always easily modify them or throw them out completely e.g. replacing them with iSCSI or RBD.

I have also adapted the way to set item titles and how to define the default boot item, so it works well with BOOT_METHOD.

I hope you see the beauty of it - independently of my Ceph/RBD efforts - but of course it makes integration of such BOOT_METHODS much easier.

I have based this patch on the current non-RBD master and will submit an additional PR for RBD, adapted to BOOT_METHOD shortly.

Sidenote:
Since ltsp.conf now contains some default configuration it would be best if it were copied to /etc/ltsp on first install.

My best regards,
Markus