### PR TITLE
Local authentification support

### DIFF
--- a/ltsp/client/init/54-pam.sh
+++ b/ltsp/client/init/54-pam.sh
@@ -6,6 +6,8 @@
 # @LTSP.CONF: PASSWORDS_x
 
 pam_main() {
+    test "$LOCAL_AUTH" != "1" ||
+        return 0
     local userpass user pass
 
     re "$_LTSP_DIR/client/login/pwmerge" \

--- a/ltsp/server/image/55-cleanup.sh
+++ b/ltsp/server/image/55-cleanup.sh
@@ -26,6 +26,8 @@ remove_printers() {
 }
 
 remove_users() {
+    test "$CLEANUP_USERS" != "0" ||
+        return 0
     mkdir -p "$_COW_DIR/tmp/pwempty" "$_COW_DIR/tmp/pwmerged"
     touch "$_COW_DIR/tmp/pwempty/passwd"
     touch "$_COW_DIR/tmp/pwempty/group"


### PR DESCRIPTION
This PR adds the next options:

- `LOCAL_AUTH=<0|1>` - for enable or disable local authentication (default: 0)
- `CLEANUP_USERS=<0|1>` - for enable or disable ltsp users cleanup (default: 1)

fixes: https://github.com/ltsp/ltsp/issues/81