### PR TITLE
Feature: ADD_IMAGE_EXCLUDES OMIT_IMAGE_EXCLUDES options

### DIFF
--- a/ltsp/server/image/65-mksquashfs.sh
+++ b/ltsp/server/image/65-mksquashfs.sh
@@ -5,7 +5,7 @@
 # Call mksquashfs to generate the image
 
 mksquashfs_main() {
-    local ef_merged
+    local ef_upstream ef_local ef_merged
 
     # Unset IONICE means use the default; IONICE="" means don't use anything
     if [ -z "${IONICE+nonempty}" ]; then
@@ -14,37 +14,36 @@ mksquashfs_main() {
             IONICE="$IONICE ionice -c3"
         fi
     fi
-
+    if [ -f /etc/ltsp/image-local.excludes ]; then
+        ef_local=/etc/ltsp/image-local.excludes
+    else
+        unset ef_local
+    fi
+    if [ -f /etc/ltsp/image.excludes ]; then
+        ef_upstream=/etc/ltsp/image.excludes
+    else
+        ef_upstream="$_APPLET_DIR/image.excludes"
+    fi
     re mkdir -p "$BASE_DIR/images"
 
-    ef_merged="$BASE_DIR/images/$_IMG_NAME.excludes"
-    if [ -f /etc/ltsp/image.excludes ]; then
-        cat /etc/ltsp/image.excludes > "$ef_merged"
-    else
-        cat "$_APPLET_DIR/image.excludes" > "$ef_merged"
+    # If variables set, we need to generate new image.excludes
+    if [ -n "$ADD_IMAGE_EXCLUDES" ] || [ -n "$OMIT_IMAGE_EXCLUDES" ]; then
+        ef_merged="$(re mktemp)"
+        exit_command "rm -f $ef_merged"
+        re cat "$ef_upstream" > "$ef_merged"
+        ef_upstream="$ef_merged"
+        if [ -n "$ef_local" ]; then
+            re cat "$ef_local" >> "$ef_merged"
+            unset ef_local
+        fi
+        add_image_excludes "$ef_merged"
+        omit_image_excludes "$ef_merged"
     fi
-
-    # Append local image excludes
-    if [ -f /etc/ltsp/image-local.excludes ]; then
-        cat /etc/ltsp/image-local.excludes >> "$ef_merged"
-    fi
-    echo "$ADD_IMAGE_EXCLUDES" | tr ' ' '\n' >> "$ef_merged"
-
-    # Remove OMIT_IMAGE_EXCLUDES
-    while read line; do
-        for pattern in $OMIT_IMAGE_EXCLUDES; do
-            test "$line" = "$pattern" ||
-            echo "$line"
-        done
-    done <"$ef_merged" >"$ef_merged.tmp"
-    mv "$ef_merged.tmp" "$ef_merged"
 
     # -regex might be nicer: https://stackoverflow.com/questions/57304278
     re $IONICE mksquashfs  "$_COW_DIR" "$BASE_DIR/images/$_IMG_NAME.img.tmp" \
-        -noappend -wildcards -ef "$ef_merged" $MKSQUASHFS_PARAMS
-
-    rm -f "$ef_merged"
-
+        -noappend -wildcards ${ef_upstream:+-ef "$ef_upstream"} \
+        ${ef_local:+-ef "$ef_local"} $MKSQUASHFS_PARAMS
     if [ "$BACKUP" != 0 ] && [ -f "$BASE_DIR/images/$_IMG_NAME.img" ]; then
         re mv "$BASE_DIR/images/$_IMG_NAME.img" "$BASE_DIR/images/$_IMG_NAME.img.old"
     fi
@@ -53,4 +52,27 @@ mksquashfs_main() {
     rw at_exit -EXIT
     echo "Running: ltsp kernel $BASE_DIR/images/$_IMG_NAME.img"
     re "$0" kernel ${KERNEL_INITRD:+-k "$KERNEL_INITRD"} "$BASE_DIR/images/$_IMG_NAME.img"
+}
+
+# Append local image excludes with ADD_IMAGE_EXCLUDES
+add_image_excludes() {
+    test -n "$ADD_IMAGE_EXCLUDES" ||
+        return 0
+    echo "$ADD_IMAGE_EXCLUDES" | tr ' ' '\n' >> "$1"
+}
+
+# Remove image excludes specified in OMIT_IMAGE_EXCLUDES
+omit_image_excludes() {
+    test -n "$OMIT_IMAGE_EXCLUDES" ||
+        return 0
+    (
+        set -f
+        while read line; do
+            for pattern in $OMIT_IMAGE_EXCLUDES; do
+                test "$line" = "$pattern" ||
+                echo "$line"
+            done
+        done <"$1" >"$1.tmp"
+        mv "$1.tmp" "$1"
+    )
 }


### PR DESCRIPTION
According https://github.com/ltsp/ltsp/issues/81#issuecomment-555912109

This PR adds two new options, example:

```
ADD_IMAGE_EXCLUDES="foo bar/* baz/sub"
OMIT_IMAGE_EXCLUDES="home/*"
```

Option `ADD_IMAGE_EXCLUDES` will add `foo`, `bar/*` and `baz/sub` to `image.excludes` during mksquashfs call (names containing spaces are not supported, do we really need them?)

Option `OMIT_IMAGE_EXCLUDES` will remove `home/*` from default `image.excludes` during mksquashfs call