### PR TITLE
Unify boolean options

### DIFF
--- a/docs/ltsp-dnsmasq.8.md
+++ b/docs/ltsp-dnsmasq.8.md
@@ -11,20 +11,20 @@ the provided parameters.
 ## OPTIONS
 See the **ltsp(8)** man page for _ltsp-options_.
 
-**-d**, **--dns=**_0|1_
+**-d**, **--dns**[=_0|1_]
 : Enable or disable the DNS service. Defaults to 0.
 Enabling the DNS service of dnsmasq allows caching of client requests,
 custom DNS results, blacklisting etc, and automatically disables
 DNSStubListener in systemd-resolved on the LTSP server.
 
-**-p**, **--proxy-dhcp=**_0|1_
+**-p**, **--proxy-dhcp**[=_0|1_]
 : Enable or disable the proxy DHCP service. Defaults to 1.
 Proxy DHCP means that the LTSP server sends the boot filename, but it leaves
 the IP leasing to an external DHCP server, for example a router or pfsense
 or a Windows DHCP server. It's the easiest way to set up LTSP, as it only
 requires a single NIC with no static IP, no need to rewire switches etc.
 
-**-r**, **--real-dhcp=**_0|1_
+**-r**, **--real-dhcp**[=_0|1_]
 : Enable or disable the real DHCP service. Defaults to 1.
 In dual NIC setups, you only need to configure the internal NIC to a static
 IP of 192.168.67.1; LTSP will try to autodetect everything else.
@@ -37,7 +37,7 @@ isc-dhcp-server on the LTSP server.
 Proxy DHCP clients don't receive DHCP options, so it's recommended to use the
 ltsp.conf DNS_SERVER parameter when autodetection isn't appropriate.
 
-**-t**, **--tftp=**_0|1_
+**-t**, **--tftp**[=_0|1_]
 : Enable or disable the TFTP service. Defaults to 1.
 
 ## EXAMPLES

--- a/docs/ltsp-image.8.md
+++ b/docs/ltsp-image.8.md
@@ -13,10 +13,10 @@ only image and then use SSHFS or NFS to mount /home/username from the server.
 ## OPTIONS
 See the **ltsp(8)** man page for _ltsp-options_.
 
-**-b**, **--backup=**_0|1_
+**-b**, **--backup**[=_0|1_]
 : Backup /srv/ltsp/images/_image_.img to _image_.img.old. Defaults to 1.
 
-**-c**, **--cleanup**=_0|1_
+**-c**, **--cleanup**[=_0|1_]
 : Create a writeable overlay on top of the image source and temporarily
 remove user accounts and sensitive data before calling mksquashfs.
 Defaults to 1.

--- a/docs/ltsp-nfs.8.md
+++ b/docs/ltsp-nfs.8.md
@@ -11,12 +11,12 @@ Install /etc/exports.d/ltsp-nfs.conf in order to export /srv/ltsp ($BASE_DIR),
 ## OPTIONS
 See the **ltsp(8)** man page for _ltsp-options_.
 
-**-h**, **--nfs-home=**_0|1_
+**-h**, **--nfs-home**[=_0|1_]
 : Export /home over NFS3. Defaults to 0.
 Note that NFS3 is insecure for home, so by default SSHFS is used.
 To specify a different directory, set $HOME_DIR in /etc/ltsp/ltsp.conf.
 
-**-t**, **--nfs-tftp=**_0|1_
+**-t**, **--nfs-tftp**[=_0|1_]
 : Export /srv/tftp/ltsp over NFS3. Defaults to 1.
 To specify a different directory, set $TFTP_DIR in /etc/ltsp/ltsp.conf.
 

--- a/ltsp/common/service/55-service.sh
+++ b/ltsp/common/service/55-service.sh
@@ -7,12 +7,12 @@
 service_cmdline() {
     local args
 
-    args=$(re getopt -n "ltsp $_APPLET" -o "s" -l \
-        "stop" -- "$@")
+    args=$(re getopt -n "ltsp $_APPLET" -o "s::" -l \
+        "stop::" -- "$@")
     eval "set -- $args"
     while true; do
         case "$1" in
-            -s|--stop) STOP=1 ;;
+            -s|--stop) shift; STOP=${1:-1} ;;
             --) shift; break ;;
             *) die "ltsp $_APPLET: error in cmdline: $*" ;;
         esac

--- a/ltsp/server/dnsmasq/55-dnsmasq.sh
+++ b/ltsp/server/dnsmasq/55-dnsmasq.sh
@@ -12,17 +12,17 @@ TFTP=${TFTP:-1}
 dnsmasq_cmdline() {
     local args
 
-    args=$(re getopt -n "ltsp $_APPLET" -o "d:p:r:s:t:" -l \
-        "dns:,proxy-dhcp:,real-dhcp:,dns-server:,tftp:" -- "$@")
+    args=$(re getopt -n "ltsp $_APPLET" -o "d::p::r::s:t::" -l \
+        "dns::,proxy-dhcp::,real-dhcp::,dns-server:,tftp::" -- "$@")
     eval "set -- $args"
     while true; do
         case "$1" in
-            -d|--dns) shift; DNS=$1 ;;
-            -p|--proxy-dhcp) shift; PROXY_DHCP=$1 ;;
-            -r|--real-dhcp) shift; REAL_DHCP=$1 ;;
+            -d|--dns) shift; DNS=${1:-1} ;;
+            -p|--proxy-dhcp) shift; PROXY_DHCP=${1:-1} ;;
+            -r|--real-dhcp) shift; REAL_DHCP=${1:-1} ;;
             -s|--dns-server) shift; DNS_SERVER=$1 ;;
             # Note that this is fine: ltsp -t... dnsmasq -t...
-            -t|--tftp) shift; TFTP=$1 ;;
+            -t|--tftp) shift; TFTP=${1:-1} ;;
             --) shift; break ;;
             *) die "ltsp $_APPLET: error in cmdline: $*" ;;
         esac

--- a/ltsp/server/image/35-image.sh
+++ b/ltsp/server/image/35-image.sh
@@ -8,13 +8,13 @@
 image_cmdline() {
     local args _COW_DIR img_src
 
-    args=$(re getopt -n "ltsp $_APPLET" -o "b:c:i:k:m:r::" -l \
-        "backup:,cleanup:,ionice:,kernel-initrd:,mksquashfs-params:,revert::" -- "$@")
+    args=$(re getopt -n "ltsp $_APPLET" -o "b::c::i:k:m:r::" -l \
+        "backup::,cleanup::,ionice:,kernel-initrd:,mksquashfs-params:,revert::" -- "$@")
     eval "set -- $args"
     while true; do
         case "$1" in
-            -b|--backup) shift; BACKUP=$1 ;;
-            -c|--cleanup) shift; CLEANUP=$1 ;;
+            -b|--backup) shift; BACKUP=${1:-1} ;;
+            -c|--cleanup) shift; CLEANUP=${1:-1} ;;
             -i|--ionice) shift; IONICE=$1 ;;
             -k|--kernel-initrd) shift; KERNEL_INITRD=$1 ;;
             -m|--mksquashfs-params) shift; MKSQUASHFS_PARAMS=$1 ;;

--- a/ltsp/server/nfs/55-nfs.sh
+++ b/ltsp/server/nfs/55-nfs.sh
@@ -10,14 +10,14 @@ NFS_TFTP=${NFS_TFTP:-1}
 nfs_cmdline() {
     local args
 
-    args=$(getopt -n "ltsp $_APPLET" -o "h:t:" -l \
-        "nfs-home:,nfs-tftp:" -- "$@") ||
+    args=$(getopt -n "ltsp $_APPLET" -o "h::t::" -l \
+        "nfs-home::,nfs-tftp::" -- "$@") ||
         usage 1
     eval "set -- $args"
     while true; do
         case "$1" in
-            -h|--nfs-home) shift; NFS_HOME=$1 ;;
-            -t|--nfs-tftp) shift; NFS_TFTP=$1 ;;
+            -h|--nfs-home) shift; NFS_HOME=${1:-1} ;;
+            -t|--nfs-tftp) shift; NFS_TFTP=${1:-1} ;;
             --) shift; break ;;
             *) die "ltsp $_APPLET: error in cmdline: $*" ;;
         esac


### PR DESCRIPTION
This PR unifies boolean options usage, eg instead of each `-d1` allows to use just `-d`