### PR TITLE
Prepare tmpfs for IMAGE_TO_RAM

### DIFF
--- a/ltsp/client/initrd-bottom/55-initrd-bottom.sh
+++ b/ltsp/client/initrd-bottom/55-initrd-bottom.sh
@@ -18,7 +18,8 @@ initrd_bottom_cmdline() {
 }
 
 initrd_bottom_main() {
-    local img_src img rest
+    local img_src img rest tmpfs
+    tmpfs=/run/initramfs/ltsp
 
     warn "Running $0"
     kernel_vars
@@ -32,11 +33,12 @@ initrd_bottom_main() {
         if [ "$IMAGE_TO_RAM" = "1" ]; then
             img=${img_src%%,*}
             rest=${img_src#$img}
-            re mkdir -p "/run/initramfs/ltsp"
-            warn "Running: cp $img /run/initramfs/ltsp/${img##*/}"
-            re cp "$img" "/run/initramfs/ltsp/${img##*/}"
-            re umount "/root"
-            img_src="/run/initramfs/ltsp/${img##*/}$rest"
+            re mkdir -p "$tmpfs/images"
+            re mount -t tmpfs -o mode=0755 tmpfs "$tmpfs/images"
+            warn "Running: cp $img $tmpfs/images/${img##*/}"
+            re cp "$img" "$tmpfs/images/${img##*/}"
+            re umount "$rootmnt"
+            img_src="$tmpfs/images/${img##*/}$rest"
         fi
         re mount_img_src "$img_src" "$rootmnt"
         re set_readahead "$rootmnt"
@@ -58,7 +60,7 @@ initrd_bottom_main() {
     test -d "$rootmnt/proc" || die "$rootmnt/proc doesn't exist in $_APPLET"
     if [ "$OVERLAY" != "0" ]; then
         re modprobe_overlay
-        re overlay "$rootmnt" "$rootmnt" "/run/initramfs/ltsp"
+        re overlay "$rootmnt" "$rootmnt" "$tmpfs/cow"
     fi
     re install_ltsp
 }


### PR DESCRIPTION
This PR:
1) moves `/run/initramfs/ltsp` to `/run/initramfs/ltsp/cow` 
2) mounting `/run/initramfs/ltsp/images` on demand when `IMAGE_TO_RAM=1` specified.

fixes: #102