### PR TITLE
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ltsp (20.04-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 20:45:32 +0000
+
 ltsp (20.04-1) unstable; urgency=medium
 
   * Fix NFS chroot booting regression (#126)

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/ltsp/ltsp/issues
+Bug-Submit: https://github.com/ltsp/ltsp/issues/new
+Repository: https://github.com/ltsp/ltsp.git
+Repository-Browse: https://github.com/ltsp/ltsp


### PR DESCRIPTION
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/ltsp/171344aa-614c-44cd-83a4-40dae7b367dc.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/171344aa-614c-44cd-83a4-40dae7b367dc/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/171344aa-614c-44cd-83a4-40dae7b367dc/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/171344aa-614c-44cd-83a4-40dae7b367dc/diffoscope)).
