### PR TITLE
Trimming section name for INCLUDE statement

### DIFF
--- a/ltsp/common/ltsp/55-config.sh
+++ b/ltsp/common/ltsp/55-config.sh
@@ -126,6 +126,7 @@ if ($0 ~ /^[ ]*\[[^]]*\]/) {  # [Section]
 } else if (tolower($0) ~ /^include *=/) {  # INCLUDE = xxx
     value=tolower($0)
     sub("include *= *", "", value)
+    gsub("[^a-z0-9]", "_", value)
     print prefix value
 } else if ($0 ~ /^[a-zA-Z0-9_]* *=/) {  # VAR = xxx
     value=$0


### PR DESCRIPTION
example `ltsp.conf`:

```
[group-asd]

[abc]
INCLUDE=group-asd
```

ini2sh generates the following code (before and after fix):

```diff
 section_unnamed() {
 # Prevent infinite recursion
 test "$section_unnamed" = 1 && return 0 || section_unnamed=1
 }
 
 section_group_asd() {
 test "$section_group_asd" = 1 && return 0 || section_group_asd=1
 
 }
 
 section_abc() {
 test "$section_abc" = 1 && return 0 || section_abc=1
-section_group-asd
+section_group_asd
 }
 
 # List all sections, to be able to loop over them
 section_list() {
     echo "\
 section_group_asd
 section_abc"
 }
 
 # Example usage: section_call "unnamed" "clients" "$MAC" "$IP" "$lower_hostname"
 section_call() {
     local section
 
     for section in "$@"; do
         case "$section" in
             unnamed)  section_unnamed "$@" ;;
             group-asd)  section_group_asd "$@" ;;
             abc)  section_abc "$@" ;;
         esac
     done
 }
```