### PR TITLE
Disable pxe-service completely in non proxy mode

### DIFF
--- a/ltsp/server/dnsmasq/55-dnsmasq.sh
+++ b/ltsp/server/dnsmasq/55-dnsmasq.sh
@@ -40,6 +40,7 @@ Aborting, please remove the LTSP5 configuration first"
     install_template "ltsp-dnsmasq.conf" "/etc/dnsmasq.d/ltsp-dnsmasq.conf" "\
 s|^port=0|$(textifb "$DNS" "#&" "&")|
 s|^dhcp-range=set:proxy.*|$(textifb "$PROXY_DHCP" "$(proxy_dhcp)" "#&")|
+s|^pxe-service.*|$(textifb "$PROXY_DHCP" "&" "#&")|
 s|^dhcp-range=192.168.67.20.*|$(textifb "$REAL_DHCP" "&" "#&")|
 s|^\(dhcp-option=option:dns-server,\).*|\1$(dns_server)|
 s|^\(tftp-root=\).*|\1$TFTP_DIR|

--- a/ltsp/server/ipxe/55-ipxe.sh
+++ b/ltsp/server/ipxe/55-ipxe.sh
@@ -59,7 +59,7 @@ To overwrite it, run: ltsp --overwrite $_APPLET ..."
     else
         client_sections=$(re client_sections)
         re install_template "ltsp.ipxe" "$TFTP_DIR/ltsp/ltsp.ipxe" "\
-s|^/srv/ltsp|$BASE_DIR|g
+s|/srv/ltsp|$BASE_DIR|g
 s|^\(set cmdline_ltsp .*\)|$(textif "$KERNEL_PARAMETERS" "\1\nset cmdline_client $KERNEL_PARAMETERS" "&")|
 s|^\(set cmdline_ltsp .*\)|$(textif "$DEFAULT_IMAGE" "\1\nset img $DEFAULT_IMAGE" "&")|
 s/\(|| set menu-timeout \)5000/$(textif "$MENU_TIMEOUT" "\1$MENU_TIMEOUT" "&")/


### PR DESCRIPTION
`pxe-service` entries in `ltsp-dnsmasq.conf` with `dhcp-proxy` disabled breaks EFI + iPXE boot from a server with single NIC and IP 192.168.67.1.
Commenting all `pxe-service` entries resolves the situation. They do seem redundant as they are only for a `tag:proxy` match apart from `pxe-service=tag:rpi,X86PC,"Raspberry Pi Boot   ",unused` which also seems *unused*.