### PR TITLE
BASE_DIR replacement fixed

### DIFF
--- a/ltsp/server/ipxe/55-ipxe.sh
+++ b/ltsp/server/ipxe/55-ipxe.sh
@@ -59,7 +59,7 @@ To overwrite it, run: ltsp --overwrite $_APPLET ..."
     else
         client_sections=$(re client_sections)
         re install_template "ltsp.ipxe" "$TFTP_DIR/ltsp/ltsp.ipxe" "\
-s|^/srv/ltsp|$BASE_DIR|g
+s|/srv/ltsp|$BASE_DIR|g
 s|^\(set cmdline_ltsp .*\)|$(textif "$KERNEL_PARAMETERS" "\1\nset cmdline_client $KERNEL_PARAMETERS" "&")|
 s|^\(set cmdline_ltsp .*\)|$(textif "$DEFAULT_IMAGE" "\1\nset img $DEFAULT_IMAGE" "&")|
 s/\(|| set menu-timeout \)5000/$(textif "$MENU_TIMEOUT" "\1$MENU_TIMEOUT" "&")/


### PR DESCRIPTION
`BASE_DIR` was not being correctly replaced with the `ltsp -b` flag. Fixed the same.