### PR TITLE
Disable pxe-service in "non-proxy" mode

### DIFF
--- a/ltsp/server/dnsmasq/55-dnsmasq.sh
+++ b/ltsp/server/dnsmasq/55-dnsmasq.sh
@@ -40,6 +40,7 @@ Aborting, please remove the LTSP5 configuration first"
     install_template "ltsp-dnsmasq.conf" "/etc/dnsmasq.d/ltsp-dnsmasq.conf" "\
 s|^port=0|$(textifb "$DNS" "#&" "&")|
 s|^dhcp-range=set:proxy.*|$(textifb "$PROXY_DHCP" "$(proxy_dhcp)" "#&")|
+s|^pxe-service.*|$(textifb "$PROXY_DHCP" "&" "#&")|
 s|^dhcp-range=192.168.67.20.*|$(textifb "$REAL_DHCP" "&" "#&")|
 s|^\(dhcp-option=option:dns-server,\).*|\1$(dns_server)|
 s|^\(tftp-root=\).*|\1$TFTP_DIR|


### PR DESCRIPTION
In continuation of discussions at - https://github.com/ltsp/ltsp/pull/415

Success and failure dnsmasq configurations and logs attached herein.

[success.conf.txt](https://github.com/ltsp/ltsp/files/6169665/success.conf.txt)
[failure.conf.txt](https://github.com/ltsp/ltsp/files/6169666/failure.conf.txt)
[success.log.txt](https://github.com/ltsp/ltsp/files/6169664/success.log.txt)
[failure.log.txt](https://github.com/ltsp/ltsp/files/6169667/failure.log.txt)


