### PR TITLE
Don't deference links to directories in /boot

### DIFF
--- a/ltsp/server/kernel/55-kernel.sh
+++ b/ltsp/server/kernel/55-kernel.sh
@@ -81,7 +81,7 @@ rpi_image() {
     echo "Symlinking $BASE_DIR/$img_name/boot/* in $TFTP_DIR/*"
     re test -f "$BASE_DIR/$img_name/boot/bootcode.bin"
     for var in "$BASE_DIR/$img_name/boot/"*; do
-        re ln -rsf "$var" "$TFTP_DIR/${var##*/}"
+        re ln -rsfn "$var" "$TFTP_DIR/${var##*/}"
     done
     # Remove old, dangling symlinks
     for var in "$TFTP_DIR/"*; do


### PR DESCRIPTION
Need for it explained beautifully herein - https://unix.stackexchange.com/a/561138/132961
Absence of `-n` flag results in yet another recursive link within a directory whenever `ltsp kernel` is executed.
This also enables us to loop mount (ro) the image, thus saving storage space when chroot doesn't need any modifications.