### PR TITLE
ltsp/server/kernel/55-kernel.sh: Remove $tmp/tmpfs subtree if /tmpfs …

### DIFF
--- a/ltsp/server/kernel/55-kernel.sh
+++ b/ltsp/server/kernel/55-kernel.sh
@@ -49,7 +49,12 @@ Please export ALL_IMAGES=1 if you want to allow this"
         exit_command "rw rmdir '$tmp'"
         # tmp has mode=0700; use a subdir to hide the mount from users
         re mkdir -p "$tmp/root" "$tmp/tmpfs"
-        exit_command "rw rmdir '$tmp/root' '$tmp/tmpfs'"
+        if [ "$(stat -fc %T "$tmp/tmpfs")" != "tmpfs" ]; then
+            exit_command "rw rmdir '$tmp/tmpfs'"
+        else
+            exit_command "rw rm -Rf '$tmp/tmpfs'"
+        fi
+        exit_command "rw rmdir '$tmp/root'"
         re mount_img_src "$img_src" "$tmp/root" "$tmp/tmpfs"
         tmp=$tmp/root
         re mkdir -p "$TFTP_DIR/ltsp/$img_name/"


### PR DESCRIPTION
…is already on a tmpfs filesystem, use rmdir (and previous unmount) elsewise.

 This is a fix-up / follow-up commit for commit 147a6593.

 It resolves failures in "ltsp kernel" command resembling this error output:

 ```
 root@disklserver:/usr/share/ltsp/server/kernel# LANG=C ltsp kernel
 Running: mount -t overlay -o upperdir=/tmp/tmp.0Zaz0s5gx0/tmpfs/0/up,lowerdir=/srv/ltsp/dlw+amd64+bullseye,workdir=/tmp/tmp.0Zaz0s5gx0/tmpfs/0/work /tmp/tmp.0Zaz0s5gx0/tmpfs /tmp/tmp.0Zaz0s5gx0/root/
 -rw-r--r-- 1 root root 71272208 Jan 26 11:15 /srv/tftp/ltsp/dlw+amd64+bullseye/initrd.img
 -rw-r--r-- 1 root root  6849216 Jan 18 16:54 /srv/tftp/ltsp/dlw+amd64+bullseye/vmlinuz
 rmdir: failed to remove '/tmp/tmp.0Zaz0s5gx0/tmpfs': Directory not empty
 LTSP command failed: rmdir /tmp/tmp.0Zaz0s5gx0/root /tmp/tmp.0Zaz0s5gx0/tmpfs
 rmdir: failed to remove '/tmp/tmp.0Zaz0s5gx0': Directory not empty
 LTSP command failed: rmdir /tmp/tmp.0Zaz0s5gx0
 ```