### PR TITLE
Make the generated dates timezone-agnostic

### DIFF
--- a/docs/Makefile.sh
+++ b/docs/Makefile.sh
@@ -212,7 +212,7 @@ main() {
         _VERSION=$(. ../ltsp/common/ltsp/55-ltsp.sh && echo "$_VERSION")
     fi
     if [ -n "$SOURCE_DATE_EPOCH" ]; then
-        _DATE=$(date -d"@$SOURCE_DATE_EPOCH" "+%Y-%m-%d")
+        _DATE=$(date -u -d"@$SOURCE_DATE_EPOCH" "+%Y-%m-%d")
     else
         _DATE=$(date "+%Y-%m-%d")
     fi


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort I noticed that ltsp could not be built reproducibly. This is because ltsp fails to pass `--utc` or `-u` to `date(1)`, meaning that the build can change depending on the current timezone.

I originally filed this in Debian as bug [#1005029](https://bugs.debian.org/1005029).