### PR TITLE
add `dhcp-mac` lines for raspberry pi

### DIFF
--- a/ltsp/server/dnsmasq/ltsp-dnsmasq.conf
+++ b/ltsp/server/dnsmasq/ltsp-dnsmasq.conf
@@ -40,6 +40,9 @@ dhcp-match=set:X86-64_EFI,option:client-arch,9
 dhcp-mac=set:rpi,b8:27:eb:*:*:*
 dhcp-mac=set:rpi,dc:a6:32:*:*:*
 dhcp-mac=set:rpi,e4:5f:01:*:*:*
+dhcp-mac=set:rpi,28:cd:c1:*:*:*
+dhcp-mac=set:rpi,2c:cf:67:*:*:*
+dhcp-mac=set:rpi,d8:3a:dd:*:*:*
 
 # Check if iPXE has the features we need: http://ipxe.org/howto/dhcpd
 # http && menu && ((pxe && bzimage) || efi)


### PR DESCRIPTION
Add dhcp-mac lines for new Raspberry Pi Trading Ltd.'s OUIs.
(I referenced OUI [here](https://maclookup.app/vendors/raspberry-pi-foundation).)

I've verified by Raspberry Pi 4B (8GB) which has `d8:3a:dd:*:*:*` MAC address and checked to boot successfully.