### PR TITLE
Look for compressed module overlay.ko.zst

### DIFF
--- a/ltsp/common/ltsp/55-images.sh
+++ b/ltsp/common/ltsp/55-images.sh
@@ -162,6 +162,17 @@ modprobe_overlay() {
             grep -q overlay /proc/filesystems &&
             return 0
     fi
+    # Try to load overlay.ko.zst from the target, newer systems support compressed modules
+    overlayko="$target/lib/modules/$(uname -r)/kernel/fs/overlayfs/overlay.ko.zst"
+    if [ -f "$overlayko" ]; then
+        # Do not `ln -s "$target/lib/modules" /lib/modules`
+        # In that case, $target is in use after modprobe
+        warn "Loading overlay module from real root" >&2
+        # insmod is availabe in Debian initramfs but not in Ubuntu
+        "$target/sbin/insmod" "$overlayko" &&
+            grep -q overlay /proc/filesystems &&
+            return 0
+    fi
     return 1
 }
 


### PR DESCRIPTION
Boot fails on newer Linux kernels (e.g.: Ubuntu 24.04) because the overlay module is now compressed in zst format, so the path of the file is different. This patch looks for the compressed modules if every other option failed before