### PR TITLE
Allow usage of an external NFS server for image storage and a custom premount script

### DIFF
--- a/ltsp/client/initrd-bottom/initramfs-tools/ltsp-hook.conf
+++ b/ltsp/client/initrd-bottom/initramfs-tools/ltsp-hook.conf
@@ -54,6 +54,16 @@ patch_dhclient() {
     fi
 }
 
+install_premount() {
+    PREMOUNT_CMD="$1"
+    if [ ! -z "$PREMOUNT_CMD" ]; then
+        echo "#!/bin/sh
+$PREMOUNT_CMD" > /scripts/init-premount/custom
+        chmod +x /scripts/init-premount/custom
+        echo '/scripts/init-premount/custom "$@"' >> /scripts/init-premount/ORDER
+    fi
+}
+
 install_ltsp_hooks() {
     local script entry order
 
@@ -122,8 +132,10 @@ patch_nbd
 patch_casper
 patch_dhclient
 install_ltsp_hooks
+install_premount '' 
 unset patch_nbd
 unset patch_casper
 unset patch_dhclient
 unset install_ltsp_hooks
 unset debug_shell
+

--- a/ltsp/common/initrd/35-initrd.sh
+++ b/ltsp/common/initrd/35-initrd.sh
@@ -37,6 +37,11 @@ initrd_main() {
     if [ -d /etc/ltsp ]; then
         re cp -a /etc/ltsp/. "$_DST_DIR/etc/ltsp/"
     fi
+    #Installing optional PREMOUNT_CMD
+    if [ ! -z "$PREMOUNT_CMD" ]; then
+	echo "Installing custom premount command: $PREMOUNT_CMD"
+	re sed -i "s#^install_premount .*#install_premount '$PREMOUNT_CMD'#g" "$_DST_DIR/conf/conf.d/00-ltsp.conf"
+    fi
     # Copy server public ssh keys; prepend "server" to each entry
     test -f "$_DST_DIR/etc/ltsp/ssh_known_hosts" ||
         rw sed "s/^/server /" /etc/ssh/ssh_host_*_key.pub > \
@@ -49,3 +54,4 @@ initrd_main() {
         re cp -a /etc/epoptes/server.crt "$_DST_DIR/etc/ltsp/epoptes.crt"
     fi
 }
+

--- a/ltsp/common/ltsp/ltsp.conf
+++ b/ltsp/common/ltsp/ltsp.conf
@@ -13,6 +13,9 @@
 [common]
 # Specify an alternative TFTP_DIR
 # TFTP_DIR=/var/lib/tftpboot
+# Use an external NFS server for system images (e.g.: a NAS with high performance and RAID)
+# Please, note that this share must be mounted also on the ltsp server
+# CUSTOM_NFS="my-nas.example.local:/my_custom_share/srv/ltsp"
 
 # In the special [clients] section, parameters for all clients can be defined.
 # Most ltsp.conf parameters should be placed here.

--- a/ltsp/common/ltsp/ltsp.conf
+++ b/ltsp/common/ltsp/ltsp.conf
@@ -16,6 +16,9 @@
 # Use an external NFS server for system images (e.g.: a NAS with high performance and RAID)
 # Please, note that this share must be mounted also on the ltsp server
 # CUSTOM_NFS="my-nas.example.local:/my_custom_share/srv/ltsp"
+# Optional command to run before mounting the NFS server (e.g.: for network authentication)
+# It should be some executable script or binary placed inside /etc/ltsp/
+# PREMOUNT_CMD="sh /etc/ltsp/bin/authenticate.sh"
 
 # In the special [clients] section, parameters for all clients can be defined.
 # Most ltsp.conf parameters should be placed here.

--- a/ltsp/server/ipxe/55-ipxe.sh
+++ b/ltsp/server/ipxe/55-ipxe.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Install iPXE binaries and configuration in TFTP
-# @LTSP.CONF: DEFAULT_IMAGE KERNEL_PARAMETERS MENU_TIMEOUT
+# @LTSP.CONF: DEFAULT_IMAGE KERNEL_PARAMETERS MENU_TIMEOUT CUSTOM_NFS
 
 ipxe_cmdline() {
     local args
@@ -73,6 +73,10 @@ s|^#.*item.*\bimages\b.*|$(textif "$items$r_items" "$items\n$r_items" "&")|
 s|^:images\$|$(textif "$items" "$gotos" "&")|
 s|^:roots\$|$(textif "$r_items" "$r_gotos" "&")|
 "
+    if [ ! -z $CUSTOM_NFS  ]; then
+        echo "Setting custom NFS server for cmdline: $CUSTOM_NFS"
+        sed -i "s&nfsroot=\${srv}:/srv/ltsp&nfsroot=$CUSTOM_NFS&g" "$TFTP_DIR/ltsp/ltsp.ipxe"
+    fi
     fi
     if [ "$BINARIES" != "0" ]; then
         re copy_binary memtest.0 /boot/memtest86+*32.bin /boot/memtest86+.bin
@@ -148,3 +152,4 @@ ipxe_name() {
     echo "$*" |
         awk '{ var=toupper($0); gsub("[^A-Z0-9]", "_", var); print "IPXE_" var }'
 }
+


### PR DESCRIPTION
### External NFS usage
LTSP already supports mounting images from an NFS share through the parameter "nfsroot" set in cmdline_method inside ltsp.ipxe. The NFS server is supposed to be hosted on the same machine that acts as an LTSP server, which can be good enough in small setups. In production environments with many clients, anyways, it could be preferable to use an external NFS server (e.g.: a commercial NAS, with disk redundancy, cache, and a high speed network port).
This patch adds a new configuration parameter, to be placed inside the "common" section in ltsp.conf, called CUSTOM_NFS, that allows the admin to set a custom NFS share specifying the full path (something like "my-nas.example.local:/my_custom_share/srv/ltsp"), because a NAS might have a different path than the simple "/srv/ltsp".
If CUSTOM_NFS is not defined, the configuration stays the same as always.

### Custom premount script
In many universities (expecially those adhering to Eduroam), network ports are protected using 802.1x authentication. This means that the initrd system should be able to authenticate before running a DHCP request. This can be easily done placing wpa_supplicant binary inside /etc/ltsp and a simple script to detect the UP interface and run wpa_supplicant on it before dhcpcd. This patch add a new configuration parameter in the "common" section of ltsp.conf, called "PREMOUNT_CMD". If this is set, a function called "install_premount" inside initramfs-tools/ltsp-hook.conf makes sure the command is run during premount init phase. If it is not set, nothing changes from the usual init procedure.